### PR TITLE
docs: remove social media links in introduction.md (Discord & Telegram)

### DIFF
--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -10,7 +10,7 @@ Treasurenet creates an audited, transparent, and secure way of interacting with 
 
 The core objective is to achieve complete integration between the digital and physical economies by introducing a hybrid medium of stored value called the **$UNIT** token. Through this, we aim to establish a unified WEB3 financial system that seamlessly combines the strengths of both digital and physical assets.
 
-_Note: Docs are under construction; Treasurenet Foundation welcomes discussion as we build in the open. Join the [Discord](https://discord.com/invite/treasurenet) here and [Telegram](https://t.me/Treasurenet_io) chat here._
+_Note: Docs are under construction; Treasurenet Foundation welcomes discussion as we build in the open. Join the Discord here and Telegram chat here._
 
 ## Features
 


### PR DESCRIPTION
Since the links of Discord and TG in `introduction.md` are invalid, we decide to remove them