### PR TITLE
docs: update EVM BlockExplorer URL to scan.treasurenet.io

### DIFF
--- a/docs/blockExplorers/intro.md
+++ b/docs/blockExplorers/intro.md
@@ -16,7 +16,7 @@ Each explorer queries data relevant to its environment. The EVM Block Explorer q
 
 |                      | Type   | URL                                    |
 | -------------------- | ------ | -------------------------------------- |
-| EVM BlockExplorer    | evm    | https://evmexplorer.treasurenet.io/    |
+| EVM BlockExplorer    | evm    | https://scan.treasurenet.io/    |
 | Cosmos BlockExplorer | cosmos | https://cosmosexplorer.treasurenet.io/ |
 
 ### Test Net


### PR DESCRIPTION
# Update EVM BlockExplorer URL

## Changes
- Updated EVM BlockExplorer URL from `https://evmexplorer.treasurenet.io/` to `https://scan.treasurenet.io/` in docs/blockExplorers/intro.md

## Reason
This change reflects the new official URL for the EVM BlockExplorer service.

## Testing
- Verified the new URL is accessible and functioning correctly
- Confirmed the documentation renders properly with the updated URL
