### PR TITLE
docs: fix TAT

### DIFF
--- a/docs/about/tokenomics/general_supply_framework.md
+++ b/docs/about/tokenomics/general_supply_framework.md
@@ -31,7 +31,7 @@ This estimate is based on the following highlighted assumptions. However, it is 
 
 We assume the first 3 periods’ growth rate to be `500%`, as we develop more RWA connections.
 
-Then, the steady-s`$REP`e growth rate be modeled as a PERT Distribution,
+Then, the steady-state growth rate be modeled as a PERT Distribution,
 defined by - `50%` as the low expected rate, `15%` as the expected rate, and `500%` as the maximum expected rate.
 
 When simulated for 500 periods, UNIT supply may resemble this following distribution. For complete details, please stay tuned for the further releases.

--- a/docs/about/tokenomics/tat_token.md
+++ b/docs/about/tokenomics/tat_token.md
@@ -1,6 +1,6 @@
 # `$REP` Token
 
-`$REP` serves as the accounting token for representing real-world asset productivity on Treasurenet. `$REP` serves as a represen`$REP`ion of the credibility of each Producer, with its utility derived from the underlying asset(s) it records. The purpose of the `$REP` is to document and verify the legitimacy of the Treasurenet economy.
+`$REP` serves as the accounting token for representing real-world asset productivity on Treasurenet. `$REP` serves as a representation of the credibility of each Producer, with its utility derived from the underlying asset(s) it records. The purpose of the `$REP` is to document and verify the legitimacy of the Treasurenet economy.
 
 On-chain proof of creditworthiness:
 `$REP` tokens serve as an on-chain proof of creditworthiness for Producers in a decentralized and anonymous manner. `$REP` can be used to transparently price asset financing. This is because `$REP` tokens track the production of assets by the Producer, which shows that the Producer has an underlying asset and whether this asset is economical.
@@ -13,4 +13,4 @@ The Treasurenet DAO is also looking to set up real-world legal structures to cla
 Although this type of legal structuring is common practice in legacy markets, combining real-world recourse with on-chain creditworthiness allows for radically transparent financing that is not possible without `$REP` and Treasurenet’s decentralized audit framework.
 
 Asset-specific indexing:
-Producers who are connected to the TN Gateway can mint `$REP` tokens on a regular basis. The rate at which `$REP` tokens are minted depends on the type of asset that is being produced. This means that the cumulative represen`$REP`ive value of an asset class can be tracked by looking at the number of `$REP` tokens that have been minted for that asset class. This information can be used to make financial decisions, such as deciding which asset classes to invest in. It is worth noting that the option to make this asset information public is in the hands of the Producers.
+Producers who are connected to the TN Gateway can mint `$REP` tokens on a regular basis. The rate at which `$REP` tokens are minted depends on the type of asset that is being produced. This means that the cumulative representative value of an asset class can be tracked by looking at the number of `$REP` tokens that have been minted for that asset class. This information can be used to make financial decisions, such as deciding which asset classes to invest in. It is worth noting that the option to make this asset information public is in the hands of the Producers.


### PR DESCRIPTION
* Corrected "steady-s`$REP`e" to "steady-state" in the description of growth rate modeling in `docs/about/tokenomics/general_supply_framework.md`.
* Fixed "represen`$REP`ion" to "representation" in the `$REP` token description in `docs/about/tokenomics/tat_token.md`.
* Corrected "represen`$REP`ive" to "representative" in the explanation of asset-specific indexing in `docs/about/tokenomics/tat_token.md`.