### PR TITLE
fix: align wallet docs with canonical mainnet config

### DIFF
--- a/docs/fundamentals/wallets/coinbase.md
+++ b/docs/fundamentals/wallets/coinbase.md
@@ -29,10 +29,10 @@ The Coinbase Wallet browser extension is a wallet for accessing Ethernet-enabled
 2. Open Settings > Network > Add Network and fill in the following network information:
 
    - Network Name : Treausurenet Mainnet Alpha
-   - New RPC URL: https://wallet.treasurenet.io
-   - Chain ID :5002
+   - New RPC URL: https://rpc.treasurenet.io
+   - Chain ID :5570
    - Currency Symbol (optional): UNIT
-   - Block Explorer URL (optional):https://evmexplorer.treasurenet.io/
+   - Block Explorer URL (optional):https://scan.treasurenet.io/
 
 ![addnetwork1](/img/docs/addnetwork1.png)
 

--- a/docs/fundamentals/wallets/metamask.md
+++ b/docs/fundamentals/wallets/metamask.md
@@ -26,10 +26,10 @@ The MetaMask browser extension is a wallet for accessing Ethernet-enabled applic
 2. Open Settings > Network > Add Network and fill in the network information below.
 
    - Network Name : Treausurenet Mainnet Alpha
-   - New RPC URL: https://wallet.treasurenet.io
-   - Chain ID：5002
+   - New RPC URL: https://rpc.treasurenet.io
+   - Chain ID：5570
    - Currency Symbol (optional): UNIT
-   - Block Explorer URL (optional)：https://evmexplorer.treasurenet.io/
+   - Block Explorer URL (optional)：https://scan.treasurenet.io/
 
 ![addmainnet](/img/docs/addmainnet5002.png)
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/blockExplorers/intro.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/blockExplorers/intro.md
@@ -16,7 +16,7 @@ Treasurenet 提供两种类型的区块浏览器：EVM Block Explorer 和 Cosmos
 
 |                      | 类型   | 链接                                   |
 | -------------------- | ------ | -------------------------------------- |
-| EVM BlockExplorer    | evm    | https://evmexplorer.treasurenet.io/    |
+| EVM BlockExplorer    | evm    | https://scan.treasurenet.io/    |
 | Cosmos BlockExplorer | cosmos | https://cosmosexplorer.treasurenet.io/ |
 
 ### 测试网

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/fundamentals/wallets/coinbase.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/fundamentals/wallets/coinbase.md
@@ -26,10 +26,10 @@ Coinbase 浏览器扩展钱包是一个用于访问支持以太坊的应用程�
 1. 在您的浏览器上打开 Coinbase 钱包扩展程序，如果您尚未登录，您可能需要登录您的 Coinbase 钱包帐户；
 2. 打开设置>网络>添加网络，填写下方网络信息：
    - Network Name : Treausurenet Mainnet Alpha
-   - New RPC URL: https://wallet.treasurenet.io
-   - Chain ID :5002
+   - New RPC URL: https://rpc.treasurenet.io
+   - Chain ID :5570
    - Currency Symbol (optional): UNIT
-   - Block Explorer URL (optional):https://evmexplorer.treasurenet.io/
+   - Block Explorer URL (optional):https://scan.treasurenet.io/
 
 ![addnetwork1](/img/docs/addnetwork1.png)
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/fundamentals/wallets/metamask.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/fundamentals/wallets/metamask.md
@@ -26,10 +26,10 @@ MetaMask 浏览器扩展是一个用于访问支持以太坊的应用程序和�
 2. 打开设置>网络>添加网络，填写下方网络信息
 
    - Network Name : Treausurenet Mainnet Alpha
-   - New RPC URL: https://wallet.treasurenet.io
-   - Chain ID：5002
+   - New RPC URL: https://rpc.treasurenet.io
+   - Chain ID：5570
    - Currency Symbol (optional): UNIT
-   - Block Explorer URL (optional)：https://evmexplorer.treasurenet.io/
+   - Block Explorer URL (optional)：https://scan.treasurenet.io/
 
 ![addmainnet](/img/docs/addmainnet5002.png)
 

--- a/static/img/featuredNetworks.json
+++ b/static/img/featuredNetworks.json
@@ -7,7 +7,7 @@
   },
   {
     "title": "Treasurenet",
-    "url": "https://evmexplorer.treasurenet.io/",
+    "url": "https://scan.treasurenet.io/",
     "group": "Mainnets",
     "icon": "https://raw.githubusercontent.com/treasurenetprotocol/docs/feature/1.0.3/static/img/logo_tn_github_noword.png",
     "invertIconInDarkMode": true,
@@ -15,7 +15,7 @@
   },
   {
     "title": "Treasurenet",
-    "url": "https://evmexploerer.testnet.treasurenet.io/",
+    "url": "https://evmexplorer.testnet.treasurenet.io/",
     "group": "Testnets",
     "icon": "https://raw.githubusercontent.com/treasurenetprotocol/docs/feature/1.0.3/static/img/logo_tn_github_noword.png"
   }

--- a/static/img/featuredNetworks_testnet.json
+++ b/static/img/featuredNetworks_testnet.json
@@ -7,14 +7,14 @@
   },
   {
     "title": "Treasurenet",
-    "url": "https://evmexplorer.treasurenet.io/",
+    "url": "https://scan.treasurenet.io/",
     "group": "Mainnets",
     "icon": "https://raw.githubusercontent.com/treasurenetprotocol/docs/feature/1.0.3/static/img/logo_tn_github_noword.png",
     "invertIconInDarkMode": true
   },
   {
     "title": "Treasurenet",
-    "url": "https://evmexploerer.testnet.treasurenet.io/",
+    "url": "https://evmexplorer.testnet.treasurenet.io/",
     "group": "Testnets",
     "icon": "https://raw.githubusercontent.com/treasurenetprotocol/docs/feature/1.0.3/static/img/logo_tn_github_noword.png",
     "isActive": true


### PR DESCRIPTION
## Summary
- align legacy MetaMask and Coinbase wallet docs with the canonical mainnet config from Wallet Setup
- update the mainnet explorer reference to https://scan.treasurenet.io/
- fix the featured networks testnet explorer typo in static config

## Context
- Linear: DEV-897
- This PR only updates docs and static documentation config in the docs repo.

## Validation
- reviewed the updated docs against docs/12/Wallet Setup.md and docs/12/WalletSetup.mdx canonical values
- no runtime code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Treasurenet Mainnet network configuration across wallet setup guides.
  * Corrected block explorer URLs in documentation and configuration files.
  * Updated documentation across English and Chinese language versions.

* **Chores**
  * Updated featured network configuration files with current network parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->